### PR TITLE
make `pbwdeforms_all` faster

### DIFF
--- a/src/DeformationBases/ArcDiagDeformBasis.jl
+++ b/src/DeformationBases/ArcDiagDeformBasis.jl
@@ -170,9 +170,10 @@ function arcdiag_to_basiselem__so_extpowers_stdmod(
                         end
                     end
                     if !zeroelem
-                        symm_basiselem =
-                            C(1 // factorial(length(basiselem))) *
-                            sum(prod(basisL[ind]) for ind in Combinatorics.permutations(basiselem))
+                        symm_basiselem = parent(zero)(
+                            fill(C(1 // factorial(length(basiselem))), factorial(length(basiselem))),
+                            [ind for ind in Combinatorics.permutations(basiselem)],
+                        )
                         entry += sign_lower_labels * normal_form(symm_basiselem, rels)
                     end
                     # end inner

--- a/src/FreeAssAlgQuadraticRelations.jl
+++ b/src/FreeAssAlgQuadraticRelations.jl
@@ -3,23 +3,19 @@ QuadraticRelations{C} = Dict{Tuple{Int, Int}, FreeAssAlgElem{C}} where {C <: Rin
 function normal_form(a::FreeAssAlgElem{C}, rels::QuadraticRelations{C}) where {C <: RingElement}
     todo = deepcopy(a)
     result = zero(parent(todo))
-    R = base_ring(a)
+    CR = base_ring(a)
+    A = parent(todo)
     while todo.length > 0
         c = leading_coefficient(todo)
-        m = leading_monomial(todo)
         exp = leading_exponent_word(todo)
-        t = c * m
+        t = leading_term(todo)
         todo -= t
 
         changed = false
         for i in 1:length(exp)-1
             if exp[i] > exp[i+1] && haskey(rels, (exp[i], exp[i+1]))
                 changed = true
-                todo +=
-                    c *
-                    parent(a)([one(R)], [exp[1:i-1]]) *
-                    rels[(exp[i], exp[i+1])] *
-                    parent(a)([one(R)], [exp[i+2:end]])
+                todo += A([c], [exp[1:i-1]]) * rels[(exp[i], exp[i+1])] * A([one(CR)], [exp[i+2:end]])
                 break
             end
         end


### PR DESCRIPTION
time comparisons

on `master` before any changes
```julia
julia> sp, _ = smash_product_lie_so_extpowers_standard_module(QQ, 4, 2);

julia> diag = ArcDiagram(4, 8, [5,6,7,12,1,2,3,9,8,11,10,4])
ABCD
ABCHHJJD

julia> @btime PBWDeformations.arcdiag_to_basiselem__so_extpowers_stdmod(diag, 4, 2, 4, sp.alg(0), sp.basisL, sp.rels)
  262.922 ms (3841810 allocations: 246.37 MiB)